### PR TITLE
Make the code in signal handler async-signal-safe

### DIFF
--- a/src/native/common/xcc_libc_support.c
+++ b/src/native/common/xcc_libc_support.c
@@ -1,0 +1,40 @@
+// Copyright (c) 2019-present, iQIYI, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#include "xcc_libc_support.h"
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void xcc_safe_memset(void* ip, char c, size_t len) {
+  char* p = (char *) ip;
+  while (len--)
+    *p++ = c;
+}
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+

--- a/src/native/common/xcc_libc_support.h
+++ b/src/native/common/xcc_libc_support.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2019-present, iQIYI, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#ifndef XCC_LIBC_SUPPORT_H
+#define XCC_LIBC_SUPPORT_H 1
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+// memset(3) is not async-signal-safe, ref: http://boston.conman.org/2016/12/17.1
+void xcc_safe_memset(void* ip, char c, size_t len);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#endif // XCC_LIBC_SUPPORT_H

--- a/src/native/common/xcc_signal.c
+++ b/src/native/common/xcc_signal.c
@@ -32,6 +32,7 @@
 #include <android/log.h>
 #include "xcc_signal.h"
 #include "xcc_errno.h"
+#include "xcc_libc_support.h"
 
 #define XCC_SIGNAL_CRASH_STACK_SIZE (1024 * 128)
 
@@ -65,7 +66,7 @@ int xcc_signal_crash_register(void (*handler)(int, siginfo_t *, void *))
     if(0 != sigaltstack(&ss, NULL)) return XCC_ERRNO_SYS;
 
     struct sigaction act;
-    memset(&act, 0, sizeof(act));
+    xcc_safe_memset(&act, 0, sizeof(act));
     sigfillset(&act.sa_mask);
     act.sa_sigaction = handler;
     act.sa_flags = SA_RESTART | SA_SIGINFO | SA_ONSTACK;
@@ -92,7 +93,7 @@ int xcc_signal_crash_unregister(void)
 int xcc_signal_crash_ignore(void)
 {
     struct sigaction act;
-    memset(&act, 0, sizeof(act));
+    xcc_safe_memset(&act, 0, sizeof(act));
     sigemptyset(&act.sa_mask);
     act.sa_handler = SIG_DFL;
     act.sa_flags = SA_RESTART;
@@ -132,7 +133,7 @@ int xcc_signal_trace_register(void (*handler)(int, siginfo_t *, void *))
     if(0 != (r = pthread_sigmask(SIG_UNBLOCK, &set, &xcc_signal_trace_oldset))) return r;
 
     //register new signal handler for SIGQUIT
-    memset(&act, 0, sizeof(act));
+    xcc_safe_memset(&act, 0, sizeof(act));
     sigfillset(&act.sa_mask);
     act.sa_sigaction = handler;
     act.sa_flags = SA_RESTART | SA_SIGINFO;


### PR DESCRIPTION
`memset(3)` is not async-signal-safe util POSIX.1-2016. Use the safe version to instead the invoking in signal handler.