### PR TITLE
[improve] don't link against libstdc++ on libxcrash_dumper

### DIFF
--- a/src/native/libxcrash_dumper/jni/Android.mk
+++ b/src/native/libxcrash_dumper/jni/Android.mk
@@ -3,7 +3,7 @@ LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 LOCAL_MODULE           := xcrash_dumper
 LOCAL_CFLAGS           := -std=c11 -Weverything -Werror -fvisibility=hidden -fPIE
-LOCAL_LDFLAGS          := -pie
+LOCAL_LDFLAGS          := -pie -nodefaultlibs
 LOCAL_LDLIBS           := -ldl -llog
 LOCAL_STATIC_LIBRARIES := lzma
 LOCAL_C_INCLUDES       := $(LOCAL_PATH) $(LOCAL_PATH)/../../common


### PR DESCRIPTION
libxcrash_dumper doesn't use any function from STL, link against `libstdc++.so` is not necessary.

Test Plan:

## Before
```shell
[simsun@Mac19 arm64-v8a (dev ✗)]$ readelf -d xcrash_dumper | grep NEEDED
  0x0000000000000001 NEEDED               Shared library: [libdl.so]
  0x0000000000000001 NEEDED               Shared library: [liblog.so]
  0x0000000000000001 NEEDED               Shared library: [libc.so]
  0x0000000000000001 NEEDED               Shared library: [libm.so]
  0x0000000000000001 NEEDED               Shared library: [libstdc++.so]
```

## After
```
[simsun@Mac19 arm64-v8a (dev ✗)]$ readelf -d xcrash_dumper | grep NEEDED
  0x0000000000000001 NEEDED               Shared library: [libdl.so]
  0x0000000000000001 NEEDED               Shared library: [liblog.so]
  0x0000000000000001 NEEDED               Shared library: [libc.so]
  0x0000000000000001 NEEDED               Shared library: [libm.so]
```